### PR TITLE
feat: Add MathPipe MVP — KB Builder from LaTeX source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Agent-generated output directories
 generations/
 
+# MathPipe KB output
+kb/
+
 # Log files
 logs/
 

--- a/config/example_functional_analysis.yaml
+++ b/config/example_functional_analysis.yaml
@@ -1,0 +1,38 @@
+# MathPipe Course Configuration
+# Functional Analysis — Example for MVP testing
+
+course_id: "func_analysis_2026"
+course_name: "Functional Analysis"
+term: "HT2026"
+
+# Source file (relative to where you run mathpipe.py)
+source_tex: "sample_data/example_chapter.tex"
+
+chapters:
+  - id: 1
+    title: "Normed Spaces and Banach Spaces"
+    prerequisites: []
+
+  - id: 2
+    title: "Bounded Linear Operators"
+    prerequisites: [1]
+
+  - id: 3
+    title: "The Baire Category Theorem and Applications"
+    prerequisites: [1, 2]
+
+# Problem sheets (for future use — not used in MVP)
+sheets:
+  - id: 1
+    filename: "sheet1.pdf"
+    chapters: [1, 2]
+  - id: 2
+    filename: "sheet2.pdf"
+    chapters: [2, 3]
+
+# Course-specific notation overrides
+notation_overrides:
+  "\\mathcal{B}(X,Y)": "space of bounded linear operators from X to Y"
+  "\\|\\cdot\\|": "norm (context-dependent — may be operator norm or space norm)"
+  "B_X": "closed unit ball of X"
+  "X^*": "continuous dual space of X"

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,122 @@
+"""
+Course Configuration Loader
+============================
+
+Loads and validates course_config.yaml files for MathPipe.
+"""
+
+import yaml
+from pathlib import Path
+from typing import Any, TypedDict
+
+
+class ChapterConfig(TypedDict, total=False):
+    """Configuration for a single chapter."""
+
+    id: int
+    title: str
+    pages: list[int]  # [start, end] — optional if using LaTeX source
+    prerequisites: list[int]
+
+
+class SheetConfig(TypedDict, total=False):
+    """Configuration for a problem sheet."""
+
+    id: int
+    filename: str
+    chapters: list[int]
+
+
+class CourseConfig(TypedDict, total=False):
+    """Full course configuration."""
+
+    course_id: str
+    course_name: str
+    term: str
+    source_pdf: str
+    source_tex: str
+    chapters: list[ChapterConfig]
+    sheets: list[SheetConfig]
+    notation_overrides: dict[str, str]
+
+
+def load_course_config(config_path: Path) -> CourseConfig:
+    """
+    Load and validate a course configuration YAML file.
+
+    Args:
+        config_path: Path to the YAML config file.
+
+    Returns:
+        Validated CourseConfig dictionary.
+
+    Raises:
+        FileNotFoundError: If config file doesn't exist.
+        ValueError: If required fields are missing or invalid.
+    """
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    with open(config_path, encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Config must be a YAML mapping, got {type(raw).__name__}")
+
+    # Validate required top-level keys
+    required = ["course_id", "course_name", "chapters"]
+    for key in required:
+        if key not in raw:
+            raise ValueError(f"Missing required key '{key}' in config")
+
+    # Validate course_id format
+    course_id = raw["course_id"]
+    if not isinstance(course_id, str) or not course_id.strip():
+        raise ValueError("course_id must be a non-empty string")
+
+    # Validate chapters
+    chapters = raw["chapters"]
+    if not isinstance(chapters, list) or len(chapters) == 0:
+        raise ValueError("chapters must be a non-empty list")
+
+    seen_ids: set[int] = set()
+    for i, ch in enumerate(chapters):
+        if not isinstance(ch, dict):
+            raise ValueError(f"Chapter {i} must be a mapping")
+        if "id" not in ch:
+            raise ValueError(f"Chapter {i} missing 'id'")
+        if "title" not in ch:
+            raise ValueError(f"Chapter {i} missing 'title'")
+
+        ch_id = ch["id"]
+        if not isinstance(ch_id, int) or ch_id < 1:
+            raise ValueError(f"Chapter id must be a positive integer, got {ch_id}")
+        if ch_id in seen_ids:
+            raise ValueError(f"Duplicate chapter id: {ch_id}")
+        seen_ids.add(ch_id)
+
+        # Validate pages if present
+        if "pages" in ch:
+            pages = ch["pages"]
+            if not isinstance(pages, list) or len(pages) != 2:
+                raise ValueError(f"Chapter {ch_id} pages must be [start, end]")
+            if pages[0] > pages[1]:
+                raise ValueError(
+                    f"Chapter {ch_id} page start ({pages[0]}) > end ({pages[1]})"
+                )
+
+    # Validate sheets if present
+    if "sheets" in raw:
+        for i, sheet in enumerate(raw["sheets"]):
+            if not isinstance(sheet, dict):
+                raise ValueError(f"Sheet {i} must be a mapping")
+            if "id" not in sheet:
+                raise ValueError(f"Sheet {i} missing 'id'")
+
+    # Validate notation_overrides if present
+    if "notation_overrides" in raw:
+        overrides = raw["notation_overrides"]
+        if not isinstance(overrides, dict):
+            raise ValueError("notation_overrides must be a mapping")
+
+    return raw  # type: ignore[return-value]

--- a/kb_writer.py
+++ b/kb_writer.py
@@ -1,0 +1,190 @@
+"""
+Knowledge Base Writer
+=====================
+
+Utilities for reading, writing, and validating JSONL knowledge base files.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def ensure_kb_dir(output_dir: Path, course_id: str, chapter_id: int) -> Path:
+    """
+    Create and return the KB directory for a chapter.
+
+    Structure: {output_dir}/{course_id}/chapter_{chapter_id}/
+
+    Args:
+        output_dir: Base output directory.
+        course_id: Course identifier.
+        chapter_id: Chapter number.
+
+    Returns:
+        Path to the chapter's KB directory.
+    """
+    kb_dir = output_dir / course_id / f"chapter_{chapter_id}"
+    kb_dir.mkdir(parents=True, exist_ok=True)
+    return kb_dir
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> int:
+    """
+    Write records to a JSONL file (one JSON object per line).
+
+    Args:
+        path: Output file path.
+        records: List of dictionaries to write.
+
+    Returns:
+        Number of records written.
+    """
+    with open(path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return len(records)
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """
+    Read records from a JSONL file.
+
+    Args:
+        path: Path to the JSONL file.
+
+    Returns:
+        List of parsed dictionaries.
+    """
+    records: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                print(f"  Warning: Invalid JSON on line {line_num} of {path}: {e}")
+    return records
+
+
+def validate_jsonl_output(path: Path) -> list[dict[str, Any]]:
+    """
+    Read and validate a KB JSONL file, reporting any issues.
+
+    Checks:
+    - File exists and is valid JSONL.
+    - Each record has required fields (id, type).
+    - IDs are unique.
+    - Confidence scores are in [0, 1].
+
+    Args:
+        path: Path to the JSONL file.
+
+    Returns:
+        List of valid records.
+    """
+    if not path.exists():
+        print(f"  Warning: Output file not found: {path}")
+        return []
+
+    records = read_jsonl(path)
+
+    if not records:
+        print(f"  Warning: No records in {path}")
+        return []
+
+    # Validate each record
+    seen_ids: set[str] = set()
+    valid_records: list[dict[str, Any]] = []
+    issues: list[str] = []
+
+    required_fields = {"id", "type"}
+    valid_types = {
+        "definition",
+        "theorem",
+        "lemma",
+        "proposition",
+        "corollary",
+        "example",
+        "remark",
+    }
+
+    for i, record in enumerate(records):
+        # Check required fields
+        missing = required_fields - set(record.keys())
+        if missing:
+            issues.append(f"Record {i}: missing fields {missing}")
+            continue
+
+        # Check type
+        if record["type"] not in valid_types:
+            issues.append(
+                f"Record {i} ({record['id']}): unknown type '{record['type']}'"
+            )
+
+        # Check unique ID
+        rid = record["id"]
+        if rid in seen_ids:
+            issues.append(f"Record {i}: duplicate id '{rid}'")
+        seen_ids.add(rid)
+
+        # Check confidence range
+        conf = record.get("confidence")
+        if conf is not None:
+            if not isinstance(conf, (int, float)) or conf < 0 or conf > 1:
+                issues.append(
+                    f"Record {i} ({rid}): confidence {conf} not in [0, 1]"
+                )
+
+        valid_records.append(record)
+
+    if issues:
+        print(f"  Validation issues in {path.name}:")
+        for issue in issues[:10]:  # cap at 10
+            print(f"    - {issue}")
+        if len(issues) > 10:
+            print(f"    ... and {len(issues) - 10} more")
+
+    return valid_records
+
+
+def summarise_kb(kb_dir: Path) -> dict[str, Any]:
+    """
+    Summarise the contents of a chapter's KB directory.
+
+    Args:
+        kb_dir: Path to the chapter KB directory.
+
+    Returns:
+        Summary dict with counts by type, confidence stats, etc.
+    """
+    summary: dict[str, Any] = {"path": str(kb_dir), "files": [], "by_type": {}}
+    total = 0
+    confidences: list[float] = []
+
+    for jsonl_file in sorted(kb_dir.glob("*.jsonl")):
+        records = read_jsonl(jsonl_file)
+        summary["files"].append(
+            {"name": jsonl_file.name, "records": len(records)}
+        )
+        for r in records:
+            rtype = r.get("type", "unknown")
+            summary["by_type"][rtype] = summary["by_type"].get(rtype, 0) + 1
+            total += 1
+            conf = r.get("confidence")
+            if isinstance(conf, (int, float)):
+                confidences.append(float(conf))
+
+    summary["total_records"] = total
+    if confidences:
+        summary["avg_confidence"] = round(sum(confidences) / len(confidences), 3)
+        summary["min_confidence"] = round(min(confidences), 3)
+        summary["low_confidence_count"] = sum(1 for c in confidences if c < 0.80)
+    else:
+        summary["avg_confidence"] = None
+        summary["min_confidence"] = None
+        summary["low_confidence_count"] = 0
+
+    return summary

--- a/latex_parser.py
+++ b/latex_parser.py
@@ -1,0 +1,155 @@
+"""
+LaTeX Source Parser
+===================
+
+Splits LaTeX source files into per-chapter text based on course configuration.
+Handles common LaTeX document structures used in Oxford-style lecture notes.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+# Patterns for chapter/section boundaries in LaTeX
+CHAPTER_PATTERNS = [
+    r"\\chapter\s*(?:\[[^\]]*\])?\s*\{([^}]*)\}",
+    r"\\section\s*(?:\[[^\]]*\])?\s*\{([^}]*)\}",
+    r"\\part\s*(?:\[[^\]]*\])?\s*\{([^}]*)\}",
+]
+
+# Combined pattern that matches any chapter-like boundary
+BOUNDARY_PATTERN = re.compile(
+    r"\\(?:chapter|section|part)\s*(?:\[[^\]]*\])?\s*\{([^}]*)\}",
+    re.MULTILINE,
+)
+
+
+def _normalise_title(title: str) -> str:
+    """Normalise a title for fuzzy matching."""
+    # Remove LaTeX commands, extra whitespace, and normalise case
+    cleaned = re.sub(r"\\[a-zA-Z]+\s*", "", title)
+    cleaned = re.sub(r"[{}]", "", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip().lower()
+    return cleaned
+
+
+def _title_matches(config_title: str, latex_title: str) -> bool:
+    """Check if a config title matches a LaTeX section title (fuzzy)."""
+    norm_config = _normalise_title(config_title)
+    norm_latex = _normalise_title(latex_title)
+
+    # Exact match after normalisation
+    if norm_config == norm_latex:
+        return True
+
+    # One contains the other
+    if norm_config in norm_latex or norm_latex in norm_config:
+        return True
+
+    # Word overlap: if >70% of config words appear in latex title
+    config_words = set(norm_config.split())
+    latex_words = set(norm_latex.split())
+    if config_words and latex_words:
+        overlap = len(config_words & latex_words)
+        if overlap / len(config_words) > 0.7:
+            return True
+
+    return False
+
+
+def split_into_chapters(
+    source_path: Path, config: dict[str, Any]
+) -> dict[int, str]:
+    """
+    Split a LaTeX source file into chapters based on course configuration.
+
+    Strategy:
+    1. Try to match chapter titles from config against LaTeX headings.
+    2. If title matching fails, use sequential assignment of found headings.
+    3. If no headings found, treat the entire file as a single chapter.
+
+    Args:
+        source_path: Path to the .tex file.
+        config: Course configuration dict with 'chapters' list.
+
+    Returns:
+        Dict mapping chapter_id -> chapter text (preserving LaTeX).
+
+    Raises:
+        FileNotFoundError: If source file doesn't exist.
+    """
+    if not source_path.exists():
+        raise FileNotFoundError(f"Source file not found: {source_path}")
+
+    source_text = source_path.read_text(encoding="utf-8")
+    chapter_configs = sorted(config["chapters"], key=lambda c: c["id"])
+    chapters: dict[int, str] = {}
+
+    # Find all section/chapter boundaries
+    boundaries = list(BOUNDARY_PATTERN.finditer(source_text))
+
+    if not boundaries:
+        # No LaTeX headings found — treat entire file as first chapter
+        if chapter_configs:
+            chapters[chapter_configs[0]["id"]] = source_text
+        return chapters
+
+    # Strategy 1: Match config titles to LaTeX headings
+    matched_boundaries: list[tuple[int, re.Match[str]]] = []
+
+    for ch_config in chapter_configs:
+        config_title = ch_config["title"]
+        for boundary in boundaries:
+            latex_title = boundary.group(1)
+            if _title_matches(config_title, latex_title):
+                matched_boundaries.append((ch_config["id"], boundary))
+                break
+
+    # If we matched at least some chapters via titles, use those
+    if matched_boundaries:
+        # Sort by position in the source
+        matched_boundaries.sort(key=lambda x: x[1].start())
+
+        for i, (ch_id, boundary) in enumerate(matched_boundaries):
+            start = boundary.start()
+            if i + 1 < len(matched_boundaries):
+                end = matched_boundaries[i + 1][1].start()
+            else:
+                end = len(source_text)
+            chapters[ch_id] = source_text[start:end].strip()
+
+        return chapters
+
+    # Strategy 2: Sequential assignment — map boundaries to configs in order
+    for i, ch_config in enumerate(chapter_configs):
+        if i < len(boundaries):
+            start = boundaries[i].start()
+            end = (
+                boundaries[i + 1].start()
+                if i + 1 < len(boundaries)
+                else len(source_text)
+            )
+            chapters[ch_config["id"]] = source_text[start:end].strip()
+
+    return chapters
+
+
+def extract_preamble(source_path: Path) -> str:
+    """
+    Extract the LaTeX preamble (everything before \\begin{document}).
+
+    Useful for extracting custom command definitions and package imports
+    that may define notation used throughout the document.
+
+    Args:
+        source_path: Path to the .tex file.
+
+    Returns:
+        Preamble text, or empty string if no \\begin{document} found.
+    """
+    source_text = source_path.read_text(encoding="utf-8")
+    match = re.search(r"\\begin\{document\}", source_text)
+    if match:
+        return source_text[: match.start()].strip()
+    return ""

--- a/mathpipe.py
+++ b/mathpipe.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""
+MathPipe: Autonomous Mathematics Learning Pipeline
+===================================================
+
+MVP — Knowledge Base Builder from LaTeX Source
+
+Extracts structured mathematical knowledge (definitions, theorems, lemmas,
+proof skeletons) from LaTeX lecture notes into JSONL knowledge base files.
+
+Usage:
+    python mathpipe.py --config config/example_functional_analysis.yaml --source sample_data/example_chapter.tex
+    python mathpipe.py --config config/my_course.yaml --source notes.tex --chapters 1,2
+    python mathpipe.py --config config/my_course.yaml --source notes.tex --model opus
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    TextBlock,
+    ToolUseBlock,
+    UserMessage,
+    ToolResultBlock,
+)
+
+from config_loader import load_course_config, CourseConfig
+from latex_parser import split_into_chapters, extract_preamble
+from kb_writer import ensure_kb_dir, validate_jsonl_output
+
+load_dotenv()
+
+
+# Available models
+MODELS: dict[str, str] = {
+    "haiku": "claude-haiku-4-5-20251001",
+    "sonnet": "claude-sonnet-4-5-20250929",
+    "opus": "claude-opus-4-5-20251101",
+}
+
+PROMPTS_DIR = Path(__file__).parent / "prompts"
+
+
+def load_kb_builder_prompt() -> str:
+    """Load the KB builder system prompt."""
+    return (PROMPTS_DIR / "kb_builder_prompt.md").read_text()
+
+
+async def run_kb_extraction(
+    chapter_text: str,
+    chapter_config: dict[str, Any],
+    course_config: CourseConfig,
+    output_dir: Path,
+    model: str,
+    preamble: str = "",
+) -> dict[str, Any]:
+    """
+    Run KB extraction for a single chapter using Claude Agent SDK.
+
+    Creates a dedicated agent session that reads the chapter source and
+    writes structured JSONL output.
+
+    Args:
+        chapter_text: The LaTeX source text for this chapter.
+        chapter_config: Config dict for this chapter (id, title, etc.).
+        course_config: Full course configuration.
+        output_dir: Base output directory for KB files.
+        model: Full model ID string.
+        preamble: LaTeX preamble (custom commands, notation).
+
+    Returns:
+        Stats dict with extraction results.
+    """
+    course_id = course_config["course_id"]
+    chapter_id = chapter_config["id"]
+    chapter_title = chapter_config["title"]
+
+    # Create workspace
+    kb_dir = ensure_kb_dir(output_dir, course_id, chapter_id)
+
+    # Write chapter source for the agent to read
+    source_file = kb_dir / "chapter_source.tex"
+    source_file.write_text(chapter_text, encoding="utf-8")
+
+    # Write preamble if available (for notation reference)
+    if preamble:
+        preamble_file = kb_dir / "preamble.tex"
+        preamble_file.write_text(preamble, encoding="utf-8")
+
+    # Output file path (agent will write here)
+    output_file = kb_dir / "kb.jsonl"
+
+    # Build system prompt
+    system_prompt = load_kb_builder_prompt()
+
+    # Build notation context
+    notation_overrides = course_config.get("notation_overrides", {})
+    notation_section = ""
+    if notation_overrides:
+        notation_section = "\n\nCourse-specific notation overrides:\n"
+        for symbol, meaning in notation_overrides.items():
+            notation_section += f"  - `{symbol}` means: {meaning}\n"
+
+    preamble_section = ""
+    if preamble:
+        preamble_section = (
+            "\n\nThe file `preamble.tex` contains the document preamble with "
+            "custom LaTeX command definitions. Read it first to understand any "
+            "custom notation used in the chapter.\n"
+        )
+
+    # Build the task message
+    task_message = f"""Extract all mathematical objects from the chapter source file.
+
+**Course:** {course_config["course_name"]} ({course_id})
+**Chapter {chapter_id}:** {chapter_title}
+**Source file:** chapter_source.tex
+**Output file:** kb.jsonl
+{notation_section}{preamble_section}
+Instructions:
+1. {"Read `preamble.tex` first for custom commands, then read" if preamble else "Read"} `chapter_source.tex`.
+2. Identify ALL definitions, theorems, lemmas, propositions, corollaries, examples, and remarks.
+3. For each, extract the structured fields as specified in your system prompt.
+4. Use the ID format: `{course_id}.ch{chapter_id}.<type_abbrev>.<number>`
+5. Write the complete JSONL to `kb.jsonl` — one JSON object per line, NO wrapping array, NO markdown fences.
+6. After writing, report a summary: count of each type extracted, any items with confidence < 0.80, and any difficulties.
+
+Be thorough. Extract EVERY formal mathematical statement in the chapter."""
+
+    print(f"\n{'='*60}")
+    print(f"  Chapter {chapter_id}: {chapter_title}")
+    print(f"  Source: {len(chapter_text):,} characters")
+    print(f"  Output: {output_file}")
+    print(f"{'='*60}\n")
+
+    # Create the agent
+    client = ClaudeSDKClient(
+        options=ClaudeAgentOptions(
+            model=model,
+            system_prompt=system_prompt,
+            allowed_tools=["Read", "Write", "Glob", "Grep"],
+            max_turns=50,
+            cwd=str(kb_dir.resolve()),
+        )
+    )
+
+    # Run the agent session
+    result_text = ""
+    ch_start = time.time()
+
+    try:
+        async with client:
+            await client.query(task_message)
+
+            async for msg in client.receive_response():
+                if isinstance(msg, AssistantMessage):
+                    for block in msg.content:
+                        if isinstance(block, TextBlock):
+                            result_text += block.text
+                            print(block.text, end="", flush=True)
+                        elif isinstance(block, ToolUseBlock):
+                            print(f"\n  [Tool: {block.name}]", flush=True)
+
+                elif isinstance(msg, UserMessage):
+                    for block in msg.content:
+                        if isinstance(block, ToolResultBlock):
+                            is_error = bool(block.is_error) if block.is_error else False
+                            if is_error:
+                                error_str = str(block.content)[:300]
+                                print(f"  [Error] {error_str}", flush=True)
+                            else:
+                                print("  [Done]", flush=True)
+
+    except Exception as e:
+        print(f"\n  Agent error: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return {
+            "chapter_id": chapter_id,
+            "title": chapter_title,
+            "status": "error",
+            "error": str(e),
+            "total_records": 0,
+            "duration_seconds": round(time.time() - ch_start, 1),
+        }
+
+    print()  # newline after streaming
+
+    # Validate output
+    stats: dict[str, Any] = {
+        "chapter_id": chapter_id,
+        "title": chapter_title,
+        "duration_seconds": round(time.time() - ch_start, 1),
+    }
+
+    if output_file.exists():
+        records = validate_jsonl_output(output_file)
+        stats["total_records"] = len(records)
+        stats["by_type"] = {}
+        for r in records:
+            rtype = r.get("type", "unknown")
+            stats["by_type"][rtype] = stats["by_type"].get(rtype, 0) + 1
+
+        confidences = [
+            r.get("confidence", 1.0)
+            for r in records
+            if isinstance(r.get("confidence"), (int, float))
+        ]
+        if confidences:
+            stats["avg_confidence"] = round(sum(confidences) / len(confidences), 3)
+            stats["low_confidence_count"] = sum(1 for c in confidences if c < 0.80)
+        else:
+            stats["avg_confidence"] = None
+            stats["low_confidence_count"] = 0
+
+        stats["status"] = "success"
+    else:
+        stats["status"] = "no_output"
+        stats["total_records"] = 0
+
+    return stats
+
+
+async def run_kb_pipeline(
+    config: CourseConfig,
+    chapters: dict[int, str],
+    output_dir: Path,
+    model_name: str,
+    preamble: str = "",
+) -> None:
+    """
+    Run the full KB extraction pipeline across all specified chapters.
+
+    Args:
+        config: Course configuration.
+        chapters: Dict mapping chapter_id -> chapter LaTeX text.
+        output_dir: Base output directory.
+        model_name: Short model name (haiku/sonnet/opus).
+        preamble: LaTeX preamble text.
+    """
+    model = MODELS[model_name]
+    course_id = config["course_id"]
+
+    print(f"\n{'='*60}")
+    print(f"  MathPipe KB Builder")
+    print(f"{'='*60}")
+    print(f"  Course: {config['course_name']} ({course_id})")
+    print(f"  Chapters: {sorted(chapters.keys())}")
+    print(f"  Model: {model_name} ({model})")
+    print(f"  Output: {output_dir / course_id}")
+    print(f"{'='*60}")
+
+    all_stats: list[dict[str, Any]] = []
+    pipeline_start = time.time()
+
+    for chapter_id in sorted(chapters.keys()):
+        chapter_text = chapters[chapter_id]
+        chapter_configs = {ch["id"]: ch for ch in config["chapters"]}
+        chapter_config = chapter_configs[chapter_id]
+
+        stats = await run_kb_extraction(
+            chapter_text=chapter_text,
+            chapter_config=chapter_config,
+            course_config=config,
+            output_dir=output_dir,
+            model=model,
+            preamble=preamble,
+        )
+        all_stats.append(stats)
+
+    total_time = round(time.time() - pipeline_start, 1)
+
+    # Print summary
+    print(f"\n{'='*60}")
+    print(f"  PIPELINE COMPLETE")
+    print(f"{'='*60}")
+    print(f"  Total time: {total_time}s")
+    print(f"  Chapters processed: {len(all_stats)}")
+
+    total_records = 0
+    for s in all_stats:
+        total_records += s.get("total_records", 0)
+        marker = "OK" if s["status"] == "success" else s["status"].upper()
+        print(f"\n  Chapter {s['chapter_id']}: {s['title']}")
+        print(f"    Status: {marker}")
+        print(f"    Records: {s.get('total_records', 0)}")
+        if s.get("by_type"):
+            for t, count in sorted(s["by_type"].items()):
+                print(f"      {t}: {count}")
+        if s.get("avg_confidence") is not None:
+            print(f"    Avg confidence: {s['avg_confidence']}")
+        if s.get("low_confidence_count", 0) > 0:
+            print(f"    Low confidence (<0.80): {s['low_confidence_count']}")
+        print(f"    Duration: {s.get('duration_seconds', '?')}s")
+
+    print(f"\n  Total KB records: {total_records}")
+
+    # Write pipeline log
+    log_dir = output_dir / course_id / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / f"pipeline_run_{int(time.time())}.json"
+    with open(log_file, "w") as f:
+        json.dump(
+            {
+                "course_id": course_id,
+                "course_name": config["course_name"],
+                "model": model_name,
+                "total_time_seconds": total_time,
+                "total_records": total_records,
+                "chapters": all_stats,
+            },
+            f,
+            indent=2,
+        )
+    print(f"\n  Pipeline log: {log_file}")
+    print(f"{'='*60}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="MathPipe — Mathematics Knowledge Base Builder (MVP)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Process all chapters from a LaTeX source
+  python mathpipe.py --config config/example_functional_analysis.yaml \\
+                     --source sample_data/example_chapter.tex
+
+  # Process specific chapters only
+  python mathpipe.py --config config/my_course.yaml --source notes.tex --chapters 1,2
+
+  # Use Opus for higher quality extraction
+  python mathpipe.py --config config/my_course.yaml --source notes.tex --model opus
+
+  # Custom output directory
+  python mathpipe.py --config config/my_course.yaml --source notes.tex --output-dir ./my_kb
+        """,
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Path to course_config.yaml",
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        required=True,
+        help="Path to LaTeX source file (.tex)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("./kb"),
+        help="Output directory for KB files (default: ./kb)",
+    )
+    parser.add_argument(
+        "--chapters",
+        type=str,
+        default=None,
+        help="Comma-separated chapter IDs to process (default: all)",
+    )
+    parser.add_argument(
+        "--model",
+        choices=list(MODELS.keys()),
+        default="sonnet",
+        help="Model for extraction (default: sonnet)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Main entry point."""
+    args = parse_args()
+
+    # Validate inputs
+    if not args.config.exists():
+        print(f"Error: Config file not found: {args.config}")
+        return 1
+    if not args.source.exists():
+        print(f"Error: Source file not found: {args.source}")
+        return 1
+
+    # Load config
+    try:
+        config = load_course_config(args.config)
+    except (ValueError, FileNotFoundError) as e:
+        print(f"Error loading config: {e}")
+        return 1
+
+    # Extract preamble for notation reference
+    preamble = extract_preamble(args.source)
+    if preamble:
+        print(f"Extracted LaTeX preamble ({len(preamble)} chars)")
+
+    # Split source into chapters
+    try:
+        chapters = split_into_chapters(args.source, config)
+    except Exception as e:
+        print(f"Error parsing source: {e}")
+        return 1
+
+    if not chapters:
+        print("Error: No chapters found in source file.")
+        print("Check that your config chapter titles match the LaTeX headings.")
+        print("The parser looks for \\chapter{...} or \\section{...} commands.")
+        return 1
+
+    # Filter chapters if specified
+    if args.chapters:
+        try:
+            chapter_ids = [int(x.strip()) for x in args.chapters.split(",")]
+        except ValueError:
+            print("Error: --chapters must be comma-separated integers (e.g., 1,2,3)")
+            return 1
+        chapters = {k: v for k, v in chapters.items() if k in chapter_ids}
+        if not chapters:
+            available = sorted(
+                ch["id"] for ch in config["chapters"]
+            )
+            print(f"Error: No matching chapters for IDs {chapter_ids}")
+            print(f"Available chapter IDs: {available}")
+            return 1
+
+    # Print chapter summary
+    print(f"\nFound {len(chapters)} chapter(s) to process:")
+    for ch_id, ch_text in sorted(chapters.items()):
+        print(f"  Chapter {ch_id}: {len(ch_text):,} characters")
+
+    # Run pipeline
+    try:
+        asyncio.run(
+            run_kb_pipeline(config, chapters, args.output_dir, args.model, preamble)
+        )
+    except KeyboardInterrupt:
+        print("\n\nInterrupted. Partial output may be in the output directory.")
+        return 130
+    except Exception as e:
+        print(f"\nFatal error: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prompts/kb_builder_prompt.md
+++ b/prompts/kb_builder_prompt.md
@@ -1,0 +1,153 @@
+## YOUR ROLE — KNOWLEDGE BASE BUILDER
+
+You are a mathematical knowledge extraction agent for MathPipe. Your job is to read a chapter of mathematical lecture notes (LaTeX source) and extract every formal mathematical object into a structured JSONL knowledge base.
+
+You are meticulous, precise, and conservative. You NEVER invent mathematical content that is not present in the source material.
+
+---
+
+### What You Extract
+
+Scan the chapter for ALL of the following:
+
+| Type | What to look for |
+|------|-----------------|
+| `definition` | `\begin{definition}`, `\begin{defn}`, or inline "We define...", "Let X be..." |
+| `theorem` | `\begin{theorem}`, `\begin{thm}`, named results |
+| `lemma` | `\begin{lemma}`, `\begin{lem}` |
+| `proposition` | `\begin{proposition}`, `\begin{prop}` |
+| `corollary` | `\begin{corollary}`, `\begin{cor}` |
+| `example` | `\begin{example}`, `\begin{eg}`, key illustrative examples |
+| `remark` | `\begin{remark}`, `\begin{rmk}`, important warnings or clarifications |
+
+Also extract results that appear WITHOUT formal LaTeX environments — some lecturers state theorems inline or use non-standard environments.
+
+---
+
+### Output Schema
+
+Write ONE JSON object per line to the output JSONL file. Each object must follow this schema:
+
+```json
+{
+  "id": "<course_id>.ch<chapter_id>.<type_abbrev>.<sequence_number>",
+  "type": "definition|theorem|lemma|proposition|corollary|example|remark",
+  "name": "Human-readable name if the result has one, otherwise null",
+  "aliases": ["Alternative names, if any"],
+  "chapter_id": 1,
+
+  "statement_latex": "Full statement preserving ALL LaTeX notation exactly as written",
+  "statement_natural": "Natural language version readable without LaTeX rendering",
+
+  "hypotheses": [
+    {
+      "id": "h1",
+      "content": "Description of each hypothesis/assumption",
+      "type": "structural|membership|bound|regularity|topological|algebraic"
+    }
+  ],
+
+  "conclusion": "What the result concludes (null for definitions)",
+
+  "proof_skeleton": {
+    "strategy": "Name of the proof strategy (e.g. contradiction, induction, direct construction, epsilon-delta, compactness argument)",
+    "steps": [
+      {
+        "step": 1,
+        "action": "What is done in this step",
+        "justification": "Why this step is valid — cite specific results if used"
+      }
+    ],
+    "hard_step": null,
+    "hard_step_explanation": null
+  },
+
+  "dependencies": ["IDs of definitions/theorems this result depends on"],
+
+  "confidence": 0.0
+}
+```
+
+**Type abbreviations for IDs:** `def`, `thm`, `lem`, `prop`, `cor`, `eg`, `rmk`
+
+Example ID: `func_analysis_2026.ch1.thm.3` (third theorem in chapter 1).
+
+---
+
+### Field-by-Field Instructions
+
+**id**: Use the format `{course_id}.ch{chapter_id}.{type_abbrev}.{N}` where N is the sequential number of that type within the chapter. Start counting at 1 for each type.
+
+**type**: One of the seven types listed above.
+
+**name**: The commonly used name (e.g. "Banach-Steinhaus Theorem", "Open Mapping Theorem"). If the result is only numbered (e.g. "Theorem 2.3"), set to `null`.
+
+**aliases**: Alternative names. Empty list `[]` if none.
+
+**statement_latex**: Copy the EXACT LaTeX from the source. Include all `$...$` and `\[...\]` environments. Do not "clean up" the LaTeX — preserve it exactly.
+
+**statement_natural**: Rewrite the statement so it can be understood without LaTeX rendering. Spell out symbols: "for all" instead of `\forall`, "element of" instead of `\in`, etc.
+
+**hypotheses**: Break the statement into its individual assumptions. Each hypothesis gets:
+- `id`: h1, h2, h3, ...
+- `content`: What the hypothesis says
+- `type`: Categorise as one of: `structural` (X is a Banach space), `membership` (f ∈ C(K)), `bound` (||x|| ≤ M), `regularity` (f is continuous), `topological` (K is compact), `algebraic` (G is a group)
+
+For definitions, list the conditions that define the object.
+
+**conclusion**: What the theorem/lemma/proposition establishes. For definitions, set to `null`.
+
+**proof_skeleton**: Extract ONLY if a proof is present in the source. Structure:
+- `strategy`: Name the overall proof technique.
+- `steps`: Break the proof into its logical steps. Use as many steps as the proof naturally requires — do NOT force a specific number. Each step needs an `action` (what is done) and `justification` (why it works).
+- `hard_step`: Which step number is the most technically demanding (integer or null).
+- `hard_step_explanation`: Why that step is hard.
+
+If NO proof is given in the source, set `proof_skeleton` to `null`.
+
+**dependencies**: List IDs of OTHER items extracted from this chapter that this result depends on. For instance, a theorem that uses Definition 1.2 should list the ID of that definition. Only reference items you have extracted — do not invent dependencies.
+
+**confidence**: Rate your extraction confidence from 0.0 to 1.0:
+- **0.90–1.00**: Statement is a formal LaTeX environment with clear boundaries. You are confident in every field.
+- **0.75–0.89**: Statement is clearly identifiable but some fields required interpretation (e.g. hypotheses not explicitly listed, proof skeleton reconstructed).
+- **0.50–0.74**: Statement is informal or ambiguous. Some fields are uncertain.
+- **Below 0.50**: You are guessing. Add `"extraction_notes"` explaining what is uncertain.
+
+---
+
+### Rules
+
+1. **NEVER invent content.** If the source does not contain a proof, set `proof_skeleton` to `null`. If you cannot determine hypotheses, set to an empty list and lower the confidence.
+
+2. **Extract EVERYTHING.** Even minor lemmas, technical propositions, and remarks. Completeness is more important than selectivity.
+
+3. **Preserve LaTeX exactly.** In `statement_latex`, copy the source notation character-for-character. Do not normalise, reformat, or "improve" the LaTeX.
+
+4. **Be specific in proof skeletons.** "Apply the main theorem" is not a useful step. "Apply Theorem 1.3 (Hahn-Banach) to the subspace W with the sublinear functional p" is.
+
+5. **Number items sequentially.** Within each type, number from 1. So `def.1`, `def.2`, ... and `thm.1`, `thm.2`, ... are separate sequences.
+
+6. **Cross-reference within the chapter.** Use the IDs you assign when listing dependencies. If Theorem 3 uses Definition 1 and Lemma 2, its dependencies should be `["<course>.ch<N>.def.1", "<course>.ch<N>.lem.2"]`.
+
+7. **Mark uncertain extractions.** If any field is uncertain, add an `"extraction_notes"` field (string) explaining what you are unsure about, and lower the confidence score accordingly.
+
+---
+
+### Process
+
+1. **Read** the chapter source file specified in your task message.
+2. **Scan** for all formal environments (`\begin{theorem}`, etc.) AND informal mathematical statements.
+3. **Extract** each item according to the schema above.
+4. **Assign dependencies** by checking which earlier results each item references.
+5. **Write** the complete JSONL file — one JSON object per line, no trailing commas, no wrapping array.
+6. **Report** a summary: count of each type extracted, any items with confidence < 0.80, and any extraction difficulties encountered.
+
+---
+
+### Common Pitfalls to Avoid
+
+- Do NOT wrap the JSONL in a JSON array `[...]`. Each line is an independent JSON object.
+- Do NOT include markdown code fences in the output file. Write raw JSONL only.
+- Do NOT truncate long statements. Include the full text even if it is several lines.
+- Do NOT merge multiple results into one record. If a theorem has a separate corollary, they are separate records.
+- Do NOT fabricate proof steps for proofs you have not seen. If the proof is left as an exercise, set `proof_skeleton` to `null`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 annotated-types==0.7.0
+PyYAML>=6.0
 anyio==4.12.1
 arcadepy==1.10.0
 attrs==25.4.0

--- a/sample_data/example_chapter.tex
+++ b/sample_data/example_chapter.tex
@@ -1,0 +1,179 @@
+\documentclass[12pt]{article}
+\usepackage{amsmath, amssymb, amsthm}
+
+\newtheorem{theorem}{Theorem}[section]
+\newtheorem{lemma}[theorem]{Lemma}
+\newtheorem{proposition}[theorem]{Proposition}
+\newtheorem{corollary}[theorem]{Corollary}
+\theoremstyle{definition}
+\newtheorem{definition}[theorem]{Definition}
+\newtheorem{example}[theorem]{Example}
+\theoremstyle{remark}
+\newtheorem{remark}[theorem]{Remark}
+
+\newcommand{\R}{\mathbb{R}}
+\newcommand{\C}{\mathbb{C}}
+\newcommand{\N}{\mathbb{N}}
+\newcommand{\norm}[1]{\|#1\|}
+\newcommand{\inner}[2]{\langle #1, #2 \rangle}
+\newcommand{\Banach}{\mathcal{B}}
+
+\begin{document}
+
+\section{Normed Spaces and Banach Spaces}
+
+We begin with the fundamental structures of functional analysis. Throughout this chapter, $\mathbb{K}$ denotes either $\R$ or $\C$.
+
+\begin{definition}[Normed Space]
+\label{def:normed-space}
+A \emph{normed space} is a pair $(X, \norm{\cdot})$ where $X$ is a vector space over $\mathbb{K}$ and $\norm{\cdot} : X \to [0, \infty)$ is a function satisfying:
+\begin{enumerate}
+    \item $\norm{x} = 0$ if and only if $x = 0$ (positive definiteness);
+    \item $\norm{\alpha x} = |\alpha| \norm{x}$ for all $\alpha \in \mathbb{K}$, $x \in X$ (absolute homogeneity);
+    \item $\norm{x + y} \leq \norm{x} + \norm{y}$ for all $x, y \in X$ (triangle inequality).
+\end{enumerate}
+\end{definition}
+
+\begin{remark}
+Every normed space $(X, \norm{\cdot})$ is a metric space with the metric $d(x,y) = \norm{x - y}$. Thus all metric space concepts (convergence, continuity, open and closed sets, compactness) apply to normed spaces.
+\end{remark}
+
+\begin{definition}[Banach Space]
+\label{def:banach-space}
+A normed space $(X, \norm{\cdot})$ is called a \emph{Banach space} if it is complete with respect to the metric $d(x,y) = \norm{x-y}$, i.e., every Cauchy sequence in $X$ converges to a limit in $X$.
+\end{definition}
+
+\begin{example}
+\label{eg:lp-spaces}
+For $1 \leq p \leq \infty$, the space $\ell^p$ consists of all sequences $(x_n)_{n \geq 1}$ in $\mathbb{K}$ with
+\[
+    \norm{x}_p = \begin{cases}
+        \left( \sum_{n=1}^{\infty} |x_n|^p \right)^{1/p} & \text{if } 1 \leq p < \infty, \\
+        \sup_{n \geq 1} |x_n| & \text{if } p = \infty.
+    \end{cases}
+\]
+Each $\ell^p$ is a Banach space. The space $c_0 \subset \ell^\infty$ of sequences converging to zero is a closed subspace, hence also a Banach space.
+\end{example}
+
+\begin{example}
+\label{eg:CK-space}
+Let $K$ be a compact Hausdorff space. The space $C(K)$ of continuous functions $f : K \to \mathbb{K}$ with the supremum norm
+\[
+    \norm{f}_\infty = \sup_{x \in K} |f(x)|
+\]
+is a Banach space.
+\end{example}
+
+\begin{definition}[Subspace]
+\label{def:subspace}
+A \emph{(closed) subspace} of a normed space $X$ is a subset $Y \subseteq X$ that is both a vector subspace and closed in the norm topology. We write $Y \leq X$.
+\end{definition}
+
+\begin{proposition}
+\label{prop:closed-subspace-banach}
+A closed subspace of a Banach space is a Banach space.
+\end{proposition}
+
+\begin{proof}
+Let $X$ be a Banach space and $Y \leq X$ a closed subspace. Let $(y_n)$ be a Cauchy sequence in $Y$. Since $Y \subseteq X$ and $X$ is complete, $(y_n)$ converges to some $y \in X$. Since $Y$ is closed, $y \in Y$. Hence $Y$ is complete.
+\end{proof}
+
+\begin{definition}[Quotient Space]
+\label{def:quotient-space}
+Let $X$ be a normed space and $Y \leq X$ a closed subspace. The \emph{quotient space} $X/Y$ is the vector space of cosets $\{x + Y : x \in X\}$ equipped with the quotient norm
+\[
+    \norm{x + Y}_{X/Y} = \inf_{y \in Y} \norm{x + y}.
+\]
+\end{definition}
+
+\begin{proposition}
+\label{prop:quotient-banach}
+If $X$ is a Banach space and $Y \leq X$, then $X/Y$ is a Banach space.
+\end{proposition}
+
+\begin{proof}
+We must show completeness. Let $(\bar{x}_n)$ be an absolutely summable sequence in $X/Y$, i.e., $\sum \norm{\bar{x}_n} < \infty$. For each $n$, choose a representative $x_n \in \bar{x}_n$ with $\norm{x_n} \leq \norm{\bar{x}_n} + 2^{-n}$. Then $\sum \norm{x_n} < \infty$, so since $X$ is complete, $s = \sum x_n$ converges in $X$. Then $\sum_{n=1}^N \bar{x}_n = \overline{s_N} \to \bar{s}$ in $X/Y$. By the absolute summability criterion for completeness, $X/Y$ is a Banach space.
+\end{proof}
+
+\begin{theorem}[Riesz's Lemma]
+\label{thm:riesz-lemma}
+Let $X$ be a normed space, $Y \leq X$ a proper closed subspace, and $0 < \theta < 1$. Then there exists $x_\theta \in X$ with $\norm{x_\theta} = 1$ and $d(x_\theta, Y) \geq \theta$.
+\end{theorem}
+
+\begin{proof}
+Since $Y \neq X$, choose $z \in X \setminus Y$. Let $d = \inf_{y \in Y} \norm{z - y} > 0$ (positive because $Y$ is closed and $z \notin Y$). Choose $y_0 \in Y$ with $\norm{z - y_0} \leq d / \theta$. Set
+\[
+    x_\theta = \frac{z - y_0}{\norm{z - y_0}}.
+\]
+Then $\norm{x_\theta} = 1$. For any $y \in Y$,
+\[
+    \norm{x_\theta - y} = \frac{\norm{z - y_0 - \norm{z-y_0} y}}{\norm{z - y_0}} = \frac{\norm{z - (y_0 + \norm{z-y_0}y)}}{\norm{z-y_0}} \geq \frac{d}{\norm{z - y_0}} \geq \theta.
+\]
+Hence $d(x_\theta, Y) \geq \theta$.
+\end{proof}
+
+\begin{corollary}
+\label{cor:finite-dim-closed}
+Every finite-dimensional subspace of a normed space is closed.
+\end{corollary}
+
+\begin{proof}
+By induction on dimension. The case $\dim = 0$ is trivial. For the inductive step, if $Y$ is finite-dimensional and $(y_n) \to x$ with $y_n \in Y$, then $(y_n)$ is bounded, and by compactness of the closed unit ball in finite dimensions (equivalence of norms), a subsequence converges in $Y$. Hence $x \in Y$.
+\end{proof}
+
+\begin{theorem}[Riesz's Theorem — Characterisation of Finite Dimension]
+\label{thm:riesz-finite-dim}
+A normed space $X$ has finite dimension if and only if the closed unit ball $B_X = \{x \in X : \norm{x} \leq 1\}$ is compact.
+\end{theorem}
+
+\begin{proof}
+$(\Rightarrow)$ If $\dim X = n < \infty$, then $X$ is isomorphic to $\mathbb{K}^n$. The unit ball is closed and bounded in $\mathbb{K}^n$, hence compact by Heine-Borel.
+
+$(\Leftarrow)$ We prove the contrapositive. Suppose $\dim X = \infty$. We construct a sequence in $B_X$ with no convergent subsequence. Choose $x_1 \in X$ with $\norm{x_1} = 1$. Let $Y_1 = \text{span}\{x_1\}$. By Riesz's Lemma (Theorem~\ref{thm:riesz-lemma}) with $\theta = 1/2$, there exists $x_2$ with $\norm{x_2} = 1$ and $\norm{x_2 - x_1} \geq 1/2$. Continuing inductively, let $Y_n = \text{span}\{x_1, \ldots, x_n\}$ and choose $x_{n+1}$ with $\norm{x_{n+1}} = 1$ and $d(x_{n+1}, Y_n) \geq 1/2$. Then $\norm{x_i - x_j} \geq 1/2$ for all $i \neq j$, so $(x_n)$ has no convergent subsequence. Thus $B_X$ is not compact.
+\end{proof}
+
+\begin{definition}[Equivalent Norms]
+\label{def:equiv-norms}
+Two norms $\norm{\cdot}_1$ and $\norm{\cdot}_2$ on a vector space $X$ are \emph{equivalent} if there exist constants $c, C > 0$ such that
+\[
+    c \norm{x}_1 \leq \norm{x}_2 \leq C \norm{x}_1 \quad \text{for all } x \in X.
+\]
+\end{definition}
+
+\begin{theorem}[Equivalence of Norms in Finite Dimensions]
+\label{thm:equiv-norms-finite-dim}
+On a finite-dimensional vector space, all norms are equivalent.
+\end{theorem}
+
+\begin{proof}
+It suffices to show every norm $\norm{\cdot}$ on $\mathbb{K}^n$ is equivalent to $\norm{\cdot}_1$. Let $e_1, \ldots, e_n$ be the standard basis.
+
+\textbf{Upper bound.} For $x = \sum \alpha_i e_i$,
+\[
+    \norm{x} \leq \sum |\alpha_i| \norm{e_i} \leq M \norm{x}_1,
+\]
+where $M = \max_i \norm{e_i}$. So the norm $\norm{\cdot}$ is continuous with respect to $\norm{\cdot}_1$.
+
+\textbf{Lower bound.} The unit sphere $S = \{x : \norm{x}_1 = 1\}$ is compact in $(\mathbb{K}^n, \norm{\cdot}_1)$. The function $x \mapsto \norm{x}$ is continuous on $S$ and strictly positive (since $x \neq 0$ on $S$). By compactness, it attains its minimum $m > 0$. So $\norm{x} \geq m$ on $S$, hence $\norm{x} \geq m \norm{x}_1$ for all $x$ by homogeneity.
+\end{proof}
+
+\begin{lemma}[Absolute Summability Criterion]
+\label{lem:abs-summability}
+A normed space $X$ is a Banach space if and only if every absolutely summable series converges, i.e., $\sum_{n=1}^\infty \norm{x_n} < \infty$ implies $\sum_{n=1}^\infty x_n$ converges in $X$.
+\end{lemma}
+
+\begin{proof}
+$(\Rightarrow)$ If $X$ is complete and $\sum \norm{x_n} < \infty$, the partial sums $s_N = \sum_{n=1}^N x_n$ form a Cauchy sequence since for $M > N$,
+\[
+    \norm{s_M - s_N} = \norm{\sum_{n=N+1}^M x_n} \leq \sum_{n=N+1}^M \norm{x_n} \to 0.
+\]
+By completeness, $(s_N)$ converges.
+
+$(\Leftarrow)$ Let $(y_n)$ be Cauchy. Choose a subsequence $(y_{n_k})$ with $\norm{y_{n_{k+1}} - y_{n_k}} \leq 2^{-k}$. Set $x_k = y_{n_{k+1}} - y_{n_k}$. Then $\sum \norm{x_k} \leq 1 < \infty$, so $\sum x_k$ converges. The partial sums of $\sum x_k$ are $y_{n_{k+1}} - y_{n_1}$, so $y_{n_k} \to y$ for some $y$. Since $(y_n)$ is Cauchy with a convergent subsequence, $y_n \to y$.
+\end{proof}
+
+\begin{remark}
+The absolute summability criterion is the standard tool for proving completeness. To show a space is Banach, take an absolutely summable series and produce its sum. This is typically easier than working directly with Cauchy sequences.
+\end{remark}
+
+\end{document}


### PR DESCRIPTION
Adds the core MathPipe pipeline that extracts structured mathematical knowledge (definitions, theorems, lemmas, proof skeletons) from LaTeX lecture notes into JSONL knowledge base files using Claude Agent SDK.

New files:
- mathpipe.py: CLI entry point and pipeline orchestration
- config_loader.py: YAML course configuration loading/validation
- latex_parser.py: LaTeX chapter splitting by title matching
- kb_writer.py: JSONL read/write/validation utilities
- prompts/kb_builder_prompt.md: KB Builder agent system prompt
- config/example_functional_analysis.yaml: Sample course config
- sample_data/example_chapter.tex: Sample LaTeX chapter for testing

Usage: python mathpipe.py --config config/example_functional_analysis.yaml \
                          --source sample_data/example_chapter.tex

https://claude.ai/code/session_01F67b7PeqeYD74La8rFt5TH